### PR TITLE
Add network (TCP) connection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 ## Introduction
 
 Home Assistant integration to control XY Screens and See Max projector screens and lifts over the
-serial and RS-485 interface.
+serial and RS-485 interface. Both direct USB-to-RS485 adapters and RS485-to-Ethernet converters
+(TCP connections) are supported.
 
 This Home Assistant integration was first implemented for XY Screens. After I was informed that the
 See Max devices use a very similar protocol support for these devices has been added.
@@ -25,6 +26,7 @@ lifts. Their devices are sold around the world under various brand names.
 ## Features
 
 - Installation/Configuration through Config Flow UI
+- Connect via USB-to-RS485 adapter or RS485-to-Ethernet converter (TCP)
 - Set the up and down duration of your projector screen/lift
 - Position control: move the screen/lift to any position along the way
 - Use multiple devices on the same RS-485 interface
@@ -52,6 +54,24 @@ I use this cheap USB RS-485 controller which you can find on
 ![image](https://raw.githubusercontent.com/rrooggiieerr/homeassistant-xyscreens/main/usb-rs485.png)
 
 See the documentation of your specific projector screen or lift on how to wire yours correctly.
+
+### Network connection (RS485-to-Ethernet converter)
+
+As an alternative to a direct USB connection you can use an RS485-to-Ethernet converter to control
+your projector screen or lift over the network via TCP. This is useful when the screen is not close
+to your Home Assistant server.
+
+Any RS485-to-Ethernet converter that provides a transparent TCP socket to the RS-485 bus should
+work. Configure it for 2400 baud 8N1 to match the device protocol.
+
+An example of such a converter is the [CDEBYTE NA111-E](https://www.cdebyte.com/products/NA111-E/2).
+
+Connect the D+ and D- terminals of the converter to the corresponding RS-485 lines of your
+projector screen or lift. The RS-485 pinout varies between screen models, so refer to the
+documentation of your specific device.
+
+When adding the device in Home Assistant, select **Network** as the connection type and enter the
+IP address and TCP port of your converter.
 
 ## Supported protocol
 
@@ -138,10 +158,13 @@ lifts*
 
 - After restarting go to **Settings** then **Devices & Services**
 - Select **+ Add integration** and type in **XY Screens**
-- Select the serial port or enter the path manually
+- Select the connection type: **Serial Port** (USB-to-RS485 adapter) or **Network**
+  (RS485-to-Ethernet converter)
+- For serial: select the serial port or enter the path manually
+- For network: enter the IP address and TCP port of your converter
 - Select the address of your device or enter the address manually
 - Select the type of device, projector screen or projector lift
-- Set the up and down times of your device.
+- Set the up and down times of your device
 - Select **Submit**
 
 A new XY Screens integration and device will now be added to your Integrations view.

--- a/custom_components/xyscreens/__init__.py
+++ b/custom_components/xyscreens/__init__.py
@@ -1,5 +1,6 @@
 """The XY Screens integration."""
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Any
@@ -14,9 +15,14 @@ from homeassistant.helpers import entity_registry as er
 
 from .const import (
     CONF_ADDRESS,
+    CONF_CONNECTION_TYPE,
+    CONF_CONNECTION_TYPE_NETWORK,
+    CONF_CONNECTION_TYPE_SERIAL,
     CONF_DEVICE_TYPE,
     CONF_DEVICE_TYPE_PROJECTOR_SCREEN,
+    CONF_HOST,
     CONF_INVERTED,
+    CONF_PORT,
     CONF_SERIAL_PORT,
     CONF_TIME_CLOSE,
     CONF_TIME_OPEN,
@@ -47,22 +53,51 @@ async def test_serial_port(serial_port):
     _LOGGER.debug("Device %s is available", serial_port)
 
 
+async def test_tcp_connection(host: str, port: int):
+    """Test the working of a TCP connection."""
+    try:
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port), timeout=5.0
+        )
+        writer.close()
+        await writer.wait_closed()
+        _LOGGER.debug("TCP connection to %s:%d is available", host, port)
+    except (asyncio.TimeoutError, OSError, ConnectionError) as ex:
+        _LOGGER.error("Failed to connect to %s:%d: %s", host, port, ex)
+        raise
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up XY Screens from a config entry."""
     await er.async_migrate_entries(hass, entry.entry_id, async_migrate_entity_entry)
 
-    # Test if the device exists.
-    serial_port = entry.data[CONF_SERIAL_PORT]
-    if not Path(serial_port).exists():
-        raise ConfigEntryNotReady(f"Device {serial_port} does not exists")
+    # Get connection type (default to serial for backward compatibility)
+    connection_type = entry.data.get(CONF_CONNECTION_TYPE, CONF_CONNECTION_TYPE_SERIAL)
 
-    # Test if we can connect to the device.
-    try:
-        await test_serial_port(serial_port)
-    except serial.SerialException as ex:
-        raise ConfigEntryNotReady(
-            f"Unable to connect to device {serial_port}: {ex}"
-        ) from ex
+    if connection_type == CONF_CONNECTION_TYPE_SERIAL:
+        # Test serial connection
+        serial_port = entry.data[CONF_SERIAL_PORT]
+        if not Path(serial_port).exists():
+            raise ConfigEntryNotReady(f"Device {serial_port} does not exist")
+
+        try:
+            await test_serial_port(serial_port)
+        except serial.SerialException as ex:
+            raise ConfigEntryNotReady(
+                f"Unable to connect to device {serial_port}: {ex}"
+            ) from ex
+
+    elif connection_type == CONF_CONNECTION_TYPE_NETWORK:
+        # Test network connection
+        host = entry.data[CONF_HOST]
+        port = entry.data[CONF_PORT]
+
+        try:
+            await test_tcp_connection(host, int(port))
+        except Exception as ex:
+            raise ConfigEntryNotReady(
+                f"Unable to connect to {host}:{port}: {ex}"
+            ) from ex
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/xyscreens/__init__.py
+++ b/custom_components/xyscreens/__init__.py
@@ -8,21 +8,18 @@ from typing import Any
 import serial
 import serial_asyncio_fast as serial_asyncio
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
 
 from .const import (
     CONF_ADDRESS,
-    CONF_CONNECTION_TYPE,
     CONF_CONNECTION_TYPE_NETWORK,
     CONF_CONNECTION_TYPE_SERIAL,
     CONF_DEVICE_TYPE,
     CONF_DEVICE_TYPE_PROJECTOR_SCREEN,
-    CONF_HOST,
     CONF_INVERTED,
-    CONF_PORT,
     CONF_SERIAL_PORT,
     CONF_TIME_CLOSE,
     CONF_TIME_OPEN,
@@ -72,7 +69,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await er.async_migrate_entries(hass, entry.entry_id, async_migrate_entity_entry)
 
     # Get connection type (default to serial for backward compatibility)
-    connection_type = entry.data.get(CONF_CONNECTION_TYPE, CONF_CONNECTION_TYPE_SERIAL)
+    connection_type = entry.data.get(CONF_TYPE, CONF_CONNECTION_TYPE_SERIAL)
 
     if connection_type == CONF_CONNECTION_TYPE_SERIAL:
         # Test serial connection

--- a/custom_components/xyscreens/config_flow.py
+++ b/custom_components/xyscreens/config_flow.py
@@ -10,7 +10,7 @@ from typing import Any
 import serial.tools.list_ports
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
-from homeassistant.const import UnitOfTime
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE, UnitOfTime
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.selector import (
@@ -29,15 +29,12 @@ from homeassistant.helpers.selector import (
 from . import test_serial_port, test_tcp_connection
 from .const import (
     CONF_ADDRESS,
-    CONF_CONNECTION_TYPE,
     CONF_CONNECTION_TYPE_NETWORK,
     CONF_CONNECTION_TYPE_SERIAL,
     CONF_DEVICE_TYPE,
     CONF_DEVICE_TYPE_PROJECTOR_LIFT,
     CONF_DEVICE_TYPE_PROJECTOR_SCREEN,
-    CONF_HOST,
     CONF_INVERTED,
-    CONF_PORT,
     CONF_SERIAL_PORT,
     CONF_TIME_CLOSE,
     CONF_TIME_OPEN,
@@ -68,7 +65,7 @@ class XYScreensConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            connection_type = user_input.get(CONF_CONNECTION_TYPE)
+            connection_type = user_input.get(CONF_TYPE)
             if connection_type in (
                 CONF_CONNECTION_TYPE_SERIAL,
                 CONF_CONNECTION_TYPE_NETWORK,
@@ -78,7 +75,7 @@ class XYScreensConfigFlow(ConfigFlow, domain=DOMAIN):
         data_schema = vol.Schema(
             {
                 vol.Required(
-                    CONF_CONNECTION_TYPE, default=CONF_CONNECTION_TYPE_SERIAL
+                    CONF_TYPE, default=CONF_CONNECTION_TYPE_SERIAL
                 ): SelectSelector(
                     SelectSelectorConfig(
                         options=[
@@ -91,7 +88,7 @@ class XYScreensConfigFlow(ConfigFlow, domain=DOMAIN):
                                 label="Network (RS485-to-Ethernet converter)",
                             ),
                         ],
-                        translation_key=CONF_CONNECTION_TYPE,
+                        translation_key=CONF_TYPE,
                     )
                 ),
             }
@@ -116,7 +113,7 @@ class XYScreensConfigFlow(ConfigFlow, domain=DOMAIN):
         connection_type = CONF_CONNECTION_TYPE_SERIAL
         if user_input is not None:
             connection_type = user_input.get(
-                CONF_CONNECTION_TYPE, CONF_CONNECTION_TYPE_SERIAL
+                CONF_TYPE, CONF_CONNECTION_TYPE_SERIAL
             )
 
         if user_input is not None and CONF_ADDRESS in user_input:
@@ -165,7 +162,7 @@ class XYScreensConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # Add hidden connection type field to preserve selection
         schema_fields[
-            vol.Required(CONF_CONNECTION_TYPE, default=connection_type)
+            vol.Required(CONF_TYPE, default=connection_type)
         ] = SelectSelector(
             SelectSelectorConfig(
                 options=[
@@ -253,7 +250,7 @@ class XYScreensConfigFlow(ConfigFlow, domain=DOMAIN):
         """Validate the user input and create data."""
         self._step_setup_connection_schema(data)
 
-        connection_type = data.get(CONF_CONNECTION_TYPE)
+        connection_type = data.get(CONF_TYPE)
         connection_string = ""
 
         if connection_type == CONF_CONNECTION_TYPE_SERIAL:
@@ -309,7 +306,7 @@ class XYScreensConfigFlow(ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         entry_data = {
-            CONF_CONNECTION_TYPE: connection_type,
+            CONF_TYPE: connection_type,
             CONF_ADDRESS: address,
             CONF_DEVICE_TYPE: data[CONF_DEVICE_TYPE],
         }

--- a/custom_components/xyscreens/config_flow.py
+++ b/custom_components/xyscreens/config_flow.py
@@ -21,15 +21,23 @@ from homeassistant.helpers.selector import (
     SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
 )
 
-from . import test_serial_port
+from . import test_serial_port, test_tcp_connection
 from .const import (
     CONF_ADDRESS,
+    CONF_CONNECTION_TYPE,
+    CONF_CONNECTION_TYPE_NETWORK,
+    CONF_CONNECTION_TYPE_SERIAL,
     CONF_DEVICE_TYPE,
     CONF_DEVICE_TYPE_PROJECTOR_LIFT,
     CONF_DEVICE_TYPE_PROJECTOR_SCREEN,
+    CONF_HOST,
     CONF_INVERTED,
+    CONF_PORT,
     CONF_SERIAL_PORT,
     CONF_TIME_CLOSE,
     CONF_TIME_OPEN,
@@ -45,48 +53,137 @@ class XYScreensConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 2
     MINOR_VERSION = 2
 
-    _step_setup_serial_schema: vol.Schema
+    _step_setup_connection_schema: vol.Schema
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step."""
-        return await self.async_step_setup_serial(user_input)
+        return await self.async_step_connection_type(user_input)
 
-    async def async_step_setup_serial(
+    async def async_step_connection_type(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the setup serial step."""
+        """Handle the connection type selection step."""
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            title, data, options = await self.validate_input_setup_serial(
+            connection_type = user_input.get(CONF_CONNECTION_TYPE)
+            if connection_type in (
+                CONF_CONNECTION_TYPE_SERIAL,
+                CONF_CONNECTION_TYPE_NETWORK,
+            ):
+                return await self.async_step_setup_connection(user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_CONNECTION_TYPE, default=CONF_CONNECTION_TYPE_SERIAL
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        options=[
+                            SelectOptionDict(
+                                value=CONF_CONNECTION_TYPE_SERIAL,
+                                label="Serial Port (RS485 USB adapter)",
+                            ),
+                            SelectOptionDict(
+                                value=CONF_CONNECTION_TYPE_NETWORK,
+                                label="Network (RS485-to-Ethernet converter)",
+                            ),
+                        ],
+                        translation_key=CONF_CONNECTION_TYPE,
+                    )
+                ),
+            }
+        )
+
+        if user_input is not None:
+            data_schema = self.add_suggested_values_to_schema(data_schema, user_input)
+
+        return self.async_show_form(
+            step_id="connection_type",
+            data_schema=data_schema,
+            errors=errors,
+        )
+
+    async def async_step_setup_connection(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the setup connection step (serial or network)."""
+        errors: dict[str, str] = {}
+
+        # Get connection type from previous step or user input
+        connection_type = CONF_CONNECTION_TYPE_SERIAL
+        if user_input is not None:
+            connection_type = user_input.get(
+                CONF_CONNECTION_TYPE, CONF_CONNECTION_TYPE_SERIAL
+            )
+
+        if user_input is not None and CONF_ADDRESS in user_input:
+            title, data, options = await self.validate_input_setup_connection(
                 user_input, errors
             )
 
             if not errors:
                 return self.async_create_entry(title=title, data=data, options=options)
 
-        ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
-        list_of_ports = {}
-        for port in ports:
-            list_of_ports[port.device] = (
-                f"{port}, s/n: {port.serial_number or 'n/a'}"
-                + (f" - {port.manufacturer}" if port.manufacturer else "")
+        # Build schema based on connection type
+        schema_fields: dict = {}
+
+        if connection_type == CONF_CONNECTION_TYPE_SERIAL:
+            ports = await self.hass.async_add_executor_job(
+                serial.tools.list_ports.comports
+            )
+            list_of_ports = {}
+            for port in ports:
+                list_of_ports[port.device] = (
+                    f"{port}, s/n: {port.serial_number or 'n/a'}"
+                    + (f" - {port.manufacturer}" if port.manufacturer else "")
+                )
+
+            schema_fields[vol.Required(CONF_SERIAL_PORT, default="")] = SelectSelector(
+                SelectSelectorConfig(
+                    options=[
+                        SelectOptionDict(value=k, label=v)
+                        for k, v in list_of_ports.items()
+                    ],
+                    custom_value=True,
+                    sort=True,
+                )
+            )
+        else:
+            schema_fields[vol.Required(CONF_HOST, default="")] = TextSelector(
+                TextSelectorConfig(type=TextSelectorType.TEXT)
+            )
+            schema_fields[vol.Required(CONF_PORT, default=9997)] = NumberSelector(
+                NumberSelectorConfig(
+                    min=1,
+                    max=65535,
+                    mode=NumberSelectorMode.BOX,
+                )
             )
 
-        self._step_setup_serial_schema = vol.Schema(
+        # Add hidden connection type field to preserve selection
+        schema_fields[
+            vol.Required(CONF_CONNECTION_TYPE, default=connection_type)
+        ] = SelectSelector(
+            SelectSelectorConfig(
+                options=[
+                    SelectOptionDict(
+                        value=connection_type,
+                        label=(
+                            "Serial Port"
+                            if connection_type == CONF_CONNECTION_TYPE_SERIAL
+                            else "Network"
+                        ),
+                    ),
+                ],
+            )
+        )
+
+        # Common fields
+        schema_fields.update(
             {
-                vol.Required(CONF_SERIAL_PORT, default=""): SelectSelector(
-                    SelectSelectorConfig(
-                        options=[
-                            SelectOptionDict(value=k, label=v)
-                            for k, v in list_of_ports.items()
-                        ],
-                        custom_value=True,
-                        sort=True,
-                    )
-                ),
                 vol.Required(CONF_ADDRESS, default=""): SelectSelector(
                     SelectSelectorConfig(
                         options=[
@@ -134,45 +231,71 @@ class XYScreensConfigFlow(ConfigFlow, domain=DOMAIN):
             }
         )
 
+        self._step_setup_connection_schema = vol.Schema(schema_fields)
+
         if user_input is not None:
             data_schema = self.add_suggested_values_to_schema(
-                self._step_setup_serial_schema, user_input
+                self._step_setup_connection_schema, user_input
             )
         else:
-            data_schema = self._step_setup_serial_schema
+            data_schema = self._step_setup_connection_schema
 
         return self.async_show_form(
-            step_id="setup_serial",
+            step_id="setup_connection",
             data_schema=data_schema,
             errors=errors,
         )
 
     # pylint: disable=W0613
-    async def validate_input_setup_serial(
+    async def validate_input_setup_connection(
         self, data: dict[str, Any], errors: dict[str, str]
     ) -> tuple[str, dict[str, Any], dict[str, Any]]:
-        """Validate the user input and create data.
+        """Validate the user input and create data."""
+        self._step_setup_connection_schema(data)
 
-        Data has the keys from _step_setup_serial_schema with values provided by the user.
-        """
-        # Validate the data can be used to set up a connection.
-        self._step_setup_serial_schema(data)
+        connection_type = data.get(CONF_CONNECTION_TYPE)
+        connection_string = ""
 
-        serial_port = data.get(CONF_SERIAL_PORT)
+        if connection_type == CONF_CONNECTION_TYPE_SERIAL:
+            serial_port = data.get(CONF_SERIAL_PORT)
 
-        if serial_port is None:
-            raise vol.error.RequiredFieldInvalid("No serial port configured")
+            if serial_port is None:
+                raise vol.error.RequiredFieldInvalid("No serial port configured")
 
-        serial_port = await self.hass.async_add_executor_job(
-            get_serial_by_id, serial_port
-        )
+            serial_port = await self.hass.async_add_executor_job(
+                get_serial_by_id, serial_port
+            )
 
-        # Test if the device exists
-        if not Path(serial_port).exists():
-            errors[CONF_SERIAL_PORT] = "nonexisting_serial_port"
+            if not Path(serial_port).exists():
+                errors[CONF_SERIAL_PORT] = "nonexisting_serial_port"
 
-        address = data.get(CONF_ADDRESS)
+            connection_string = serial_port
+
+            if errors.get(CONF_SERIAL_PORT) is None:
+                try:
+                    await test_serial_port(serial_port)
+                except serial.SerialException:
+                    errors["base"] = "cannot_connect"
+
+        elif connection_type == CONF_CONNECTION_TYPE_NETWORK:
+            host = data.get(CONF_HOST)
+            port = data.get(CONF_PORT)
+
+            if not host:
+                errors[CONF_HOST] = "invalid_host"
+            if not port or port < 1 or port > 65535:
+                errors[CONF_PORT] = "invalid_port"
+
+            connection_string = f"{host}:{int(port)}"
+
+            if not errors.get(CONF_HOST) and not errors.get(CONF_PORT):
+                try:
+                    await test_tcp_connection(host, int(port))
+                except Exception:
+                    errors["base"] = "cannot_connect"
+
         # Validate the address.
+        address = data.get(CONF_ADDRESS)
         try:
             address = bytes.fromhex(address)
             address = address.hex()
@@ -182,25 +305,24 @@ class XYScreensConfigFlow(ConfigFlow, domain=DOMAIN):
         except ValueError:
             errors[CONF_ADDRESS] = "invalid_address"
 
-        # Make sure the serial port and address is not already used.
-        await self.async_set_unique_id(f"{serial_port}-{address}")
+        await self.async_set_unique_id(f"{connection_string}-{address}")
         self._abort_if_unique_id_configured()
 
-        if errors.get(CONF_SERIAL_PORT) is None:
-            # Test if we can connect to the device.
-            try:
-                await test_serial_port(serial_port)
-            except serial.SerialException:
-                errors["base"] = "cannot_connect"
+        entry_data = {
+            CONF_CONNECTION_TYPE: connection_type,
+            CONF_ADDRESS: address,
+            CONF_DEVICE_TYPE: data[CONF_DEVICE_TYPE],
+        }
 
-        # Return title, data and options
+        if connection_type == CONF_CONNECTION_TYPE_SERIAL:
+            entry_data[CONF_SERIAL_PORT] = connection_string
+        else:
+            entry_data[CONF_HOST] = data[CONF_HOST]
+            entry_data[CONF_PORT] = data[CONF_PORT]
+
         return (
-            f"{serial_port} {address.upper()}",
-            {
-                CONF_SERIAL_PORT: serial_port,
-                CONF_ADDRESS: address,
-                CONF_DEVICE_TYPE: data[CONF_DEVICE_TYPE],
-            },
+            f"{connection_string} {address.upper()}",
+            entry_data,
             {
                 CONF_TIME_OPEN: data[CONF_TIME_OPEN],
                 CONF_TIME_CLOSE: data[CONF_TIME_CLOSE],

--- a/custom_components/xyscreens/const.py
+++ b/custom_components/xyscreens/const.py
@@ -2,7 +2,12 @@
 
 DOMAIN = "xyscreens"
 
+CONF_CONNECTION_TYPE = "connection_type"
+CONF_CONNECTION_TYPE_SERIAL = "serial"
+CONF_CONNECTION_TYPE_NETWORK = "network"
 CONF_SERIAL_PORT = "serial_port"
+CONF_HOST = "host"
+CONF_PORT = "port"
 CONF_ADDRESS = "address"
 CONF_DEVICE_TYPE = "device_type"
 CONF_DEVICE_TYPE_PROJECTOR_SCREEN = "projector_screen"

--- a/custom_components/xyscreens/const.py
+++ b/custom_components/xyscreens/const.py
@@ -2,12 +2,9 @@
 
 DOMAIN = "xyscreens"
 
-CONF_CONNECTION_TYPE = "connection_type"
 CONF_CONNECTION_TYPE_SERIAL = "serial"
 CONF_CONNECTION_TYPE_NETWORK = "network"
 CONF_SERIAL_PORT = "serial_port"
-CONF_HOST = "host"
-CONF_PORT = "port"
 CONF_ADDRESS = "address"
 CONF_DEVICE_TYPE = "device_type"
 CONF_DEVICE_TYPE_PROJECTOR_SCREEN = "projector_screen"

--- a/custom_components/xyscreens/cover.py
+++ b/custom_components/xyscreens/cover.py
@@ -13,6 +13,7 @@ from homeassistant.components.cover import (
     CoverEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -21,14 +22,11 @@ from xyscreens import XYScreens, XYScreensState
 
 from .const import (
     CONF_ADDRESS,
-    CONF_CONNECTION_TYPE,
     CONF_CONNECTION_TYPE_NETWORK,
     CONF_CONNECTION_TYPE_SERIAL,
     CONF_DEVICE_TYPE,
     CONF_DEVICE_TYPE_PROJECTOR_LIFT,
-    CONF_HOST,
     CONF_INVERTED,
-    CONF_PORT,
     CONF_SERIAL_PORT,
     CONF_TIME_CLOSE,
     CONF_TIME_OPEN,
@@ -47,7 +45,7 @@ async def async_setup_entry(
     """Set up the XY Screens cover."""
     # Build connection string based on connection type
     connection_type = config_entry.data.get(
-        CONF_CONNECTION_TYPE, CONF_CONNECTION_TYPE_SERIAL
+        CONF_TYPE, CONF_CONNECTION_TYPE_SERIAL
     )
 
     if connection_type == CONF_CONNECTION_TYPE_NETWORK:

--- a/custom_components/xyscreens/cover.py
+++ b/custom_components/xyscreens/cover.py
@@ -18,7 +18,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
-from xyscreens import XYScreens, XYScreensState
+from xyscreens import XYScreens, XYScreensState, XYScreensTCP
 
 from .const import (
     CONF_ADDRESS,
@@ -43,27 +43,27 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the XY Screens cover."""
-    # Build connection string based on connection type
     connection_type = config_entry.data.get(
         CONF_TYPE, CONF_CONNECTION_TYPE_SERIAL
     )
+    address = bytes.fromhex(config_entry.data.get(CONF_ADDRESS, "AAEEEE"))
+    time_open = config_entry.options.get(CONF_TIME_OPEN)
+    time_close = config_entry.options.get(CONF_TIME_CLOSE)
 
     if connection_type == CONF_CONNECTION_TYPE_NETWORK:
         host = config_entry.data.get(CONF_HOST)
-        port = config_entry.data.get(CONF_PORT)
-        connection_string = f"{host}:{int(port)}"
+        port = int(config_entry.data.get(CONF_PORT))
+        screen = XYScreensTCP(host, port, address, time_open, time_close)
     else:
-        connection_string = config_entry.data.get(CONF_SERIAL_PORT)
+        serial_port = config_entry.data.get(CONF_SERIAL_PORT)
+        screen = XYScreens(serial_port, address, time_open, time_close)
 
     async_add_entities(
         [
             XYScreensCover(
                 config_entry.entry_id,
-                connection_string,
-                bytes.fromhex(config_entry.data.get(CONF_ADDRESS, "AAEEEE")),
+                screen,
                 config_entry.data.get(CONF_DEVICE_TYPE),
-                config_entry.options.get(CONF_TIME_OPEN),
-                config_entry.options.get(CONF_TIME_CLOSE),
                 config_entry.options.get(CONF_INVERTED),
             )
         ]
@@ -87,11 +87,8 @@ class XYScreensCover(CoverEntity, RestoreEntity):
     def __init__(
         self,
         config_entry_id: str,
-        connection_string: str,
-        address: bytes,
+        screen: XYScreens | XYScreensTCP,
         device_type: str,
-        time_open: int,
-        time_close: int,
         inverted: bool,
     ) -> None:
         """Initialize the screen."""
@@ -117,7 +114,7 @@ class XYScreensCover(CoverEntity, RestoreEntity):
             name=None,  # Inherit the device name
         )
 
-        self._screen = XYScreens(connection_string, address, time_open, time_close)
+        self._screen = screen
 
         self._inverted = inverted
 

--- a/custom_components/xyscreens/cover.py
+++ b/custom_components/xyscreens/cover.py
@@ -21,9 +21,14 @@ from xyscreens import XYScreens, XYScreensState
 
 from .const import (
     CONF_ADDRESS,
+    CONF_CONNECTION_TYPE,
+    CONF_CONNECTION_TYPE_NETWORK,
+    CONF_CONNECTION_TYPE_SERIAL,
     CONF_DEVICE_TYPE,
     CONF_DEVICE_TYPE_PROJECTOR_LIFT,
+    CONF_HOST,
     CONF_INVERTED,
+    CONF_PORT,
     CONF_SERIAL_PORT,
     CONF_TIME_CLOSE,
     CONF_TIME_OPEN,
@@ -40,11 +45,23 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the XY Screens cover."""
+    # Build connection string based on connection type
+    connection_type = config_entry.data.get(
+        CONF_CONNECTION_TYPE, CONF_CONNECTION_TYPE_SERIAL
+    )
+
+    if connection_type == CONF_CONNECTION_TYPE_NETWORK:
+        host = config_entry.data.get(CONF_HOST)
+        port = config_entry.data.get(CONF_PORT)
+        connection_string = f"{host}:{int(port)}"
+    else:
+        connection_string = config_entry.data.get(CONF_SERIAL_PORT)
+
     async_add_entities(
         [
             XYScreensCover(
                 config_entry.entry_id,
-                config_entry.data.get(CONF_SERIAL_PORT),
+                connection_string,
                 bytes.fromhex(config_entry.data.get(CONF_ADDRESS, "AAEEEE")),
                 config_entry.data.get(CONF_DEVICE_TYPE),
                 config_entry.options.get(CONF_TIME_OPEN),
@@ -72,7 +89,7 @@ class XYScreensCover(CoverEntity, RestoreEntity):
     def __init__(
         self,
         config_entry_id: str,
-        serial_port: str,
+        connection_string: str,
         address: bytes,
         device_type: str,
         time_open: int,
@@ -102,7 +119,7 @@ class XYScreensCover(CoverEntity, RestoreEntity):
             name=None,  # Inherit the device name
         )
 
-        self._screen = XYScreens(serial_port, address, time_open, time_close)
+        self._screen = XYScreens(connection_string, address, time_open, time_close)
 
         self._inverted = inverted
 

--- a/custom_components/xyscreens/manifest.json
+++ b/custom_components/xyscreens/manifest.json
@@ -13,7 +13,7 @@
   	"xyscreens"
   ],
   "requirements": [
-    "xyscreens==1.0.1"
+    "xyscreens @ git+https://github.com/s256/xyscreens.py.git@tcp-connection"
   ],
-  "version": "1.0.3"
+  "version": "1.1.0"
 }

--- a/custom_components/xyscreens/manifest.json
+++ b/custom_components/xyscreens/manifest.json
@@ -13,7 +13,7 @@
   	"xyscreens"
   ],
   "requirements": [
-    "xyscreens @ git+https://github.com/s256/xyscreens.py.git@tcp-connection"
+    "xyscreens>=1.1.0"
   ],
   "version": "1.1.0"
 }

--- a/custom_components/xyscreens/translations/en.json
+++ b/custom_components/xyscreens/translations/en.json
@@ -5,14 +5,31 @@
     },
     "error": {
       "cannot_connect": "Failed to connect",
-      "nonexisting_serial_port": "Serial poort does not exist",
+      "nonexisting_serial_port": "Serial port does not exist",
       "invalid_address": "Invalid address",
+      "invalid_host": "Invalid host address",
+      "invalid_port": "Invalid port number",
       "unknown": "Unexpected error"
     },
     "step": {
-      "setup_serial": {
+      "connection_type": {
+        "title": "Connection Type",
+        "description": "Choose how to connect to your XY Screens device.",
+        "data": {
+          "connection_type": "Connection Type"
+        },
+        "data_description": {
+          "connection_type": "Select whether to connect via a serial port (RS485 USB adapter) or network (RS485-to-Ethernet converter)."
+        }
+      },
+      "setup_connection": {
+        "title": "Device Setup",
+        "description": "Configure your XY Screens device connection and settings.",
         "data": {
           "serial_port": "Serial port",
+          "host": "Host/IP Address",
+          "port": "Port",
+          "connection_type": "Connection Type",
           "address": "Address",
           "device_type": "Device type",
           "time_open": "Open time",
@@ -20,16 +37,26 @@
           "inverted": "Invert behaviour"
         },
         "data_description": {
-          "serial_port": "The serial port your device is connected to.",
-          "address": "The hexadecimal address of the device.",
-          "time_open": "Time needed to open the device.",
-          "time_close": "Time needed to close the device.",
+          "serial_port": "The serial port your RS485 USB adapter is connected to.",
+          "host": "The IP address of your RS485-to-Ethernet converter.",
+          "port": "The TCP port number of your RS485-to-Ethernet converter.",
+          "connection_type": "The connection method (Serial or Network).",
+          "address": "The hexadecimal address of the device (AAEEEE for XY Screens, EEEEEE for See Max).",
+          "device_type": "The type of device you are connecting.",
+          "time_open": "Time in seconds needed to fully open/retract the device.",
+          "time_close": "Time in seconds needed to fully close/extend the device.",
           "inverted": "This integration follows the Cover Entity, where open means the screen is retracted and closed the screen is extracted, the same way curtains and garage doors work. For a projection screen this is counterintuitive. You can reverse the behavior."
         }
       }
     }
   },
   "selector": {
+    "connection_type": {
+      "options": {
+        "serial": "Serial Port (RS485 USB adapter)",
+        "network": "Network (RS485-to-Ethernet converter)"
+      }
+    },
     "device_type": {
       "options": {
         "projector_screen": "Projector screen",

--- a/custom_components/xyscreens/translations/en.json
+++ b/custom_components/xyscreens/translations/en.json
@@ -16,10 +16,10 @@
         "title": "Connection Type",
         "description": "Choose how to connect to your XY Screens device.",
         "data": {
-          "connection_type": "Connection Type"
+          "type": "Connection Type"
         },
         "data_description": {
-          "connection_type": "Select whether to connect via a serial port (RS485 USB adapter) or network (RS485-to-Ethernet converter)."
+          "type": "Select whether to connect via a serial port (RS485 USB adapter) or network (RS485-to-Ethernet converter)."
         }
       },
       "setup_connection": {
@@ -29,7 +29,7 @@
           "serial_port": "Serial port",
           "host": "Host/IP Address",
           "port": "Port",
-          "connection_type": "Connection Type",
+          "type": "Connection Type",
           "address": "Address",
           "device_type": "Device type",
           "time_open": "Open time",
@@ -40,7 +40,7 @@
           "serial_port": "The serial port your RS485 USB adapter is connected to.",
           "host": "The IP address of your RS485-to-Ethernet converter.",
           "port": "The TCP port number of your RS485-to-Ethernet converter.",
-          "connection_type": "The connection method (Serial or Network).",
+          "type": "The connection method (Serial or Network).",
           "address": "The hexadecimal address of the device (AAEEEE for XY Screens, EEEEEE for See Max).",
           "device_type": "The type of device you are connecting.",
           "time_open": "Time in seconds needed to fully open/retract the device.",
@@ -51,7 +51,7 @@
     }
   },
   "selector": {
-    "connection_type": {
+    "type": {
       "options": {
         "serial": "Serial Port (RS485 USB adapter)",
         "network": "Network (RS485-to-Ethernet converter)"


### PR DESCRIPTION
## Summary

Adds support for connecting to XY Screens devices via RS485-to-Ethernet converters (TCP), in addition to the existing direct serial/USB connection.

**Depends on:** rrooggiieerr/xyscreens.py#7 (TCP connection support in the library)

## Changes

### Config flow
- New **2-step config flow**: first select connection type (Serial / Network), then configure the connection
- Network mode shows Host/IP and Port fields (default port 9997)
- Serial mode shows the existing serial port picker
- Common fields (address, device type, timing, invert) shared between both modes

### Integration setup (`__init__.py`)
- `test_tcp_connection()` function for validating network connectivity during setup
- `async_setup_entry` routes between serial and TCP connection tests based on `connection_type`
- Backward compatible: existing serial-only config entries default to serial type

### Cover entity (`cover.py`)
- Builds connection string as `host:port` for network, serial path for serial
- Passes connection string to `XYScreens()` constructor (library handles routing)

### Constants (`const.py`)
- `CONF_CONNECTION_TYPE`, `CONF_CONNECTION_TYPE_SERIAL`, `CONF_CONNECTION_TYPE_NETWORK`
- `CONF_HOST`, `CONF_PORT`

### Translations
- English translations for connection type selection, host, port fields and error messages

### Manifest
- `requirements` updated to `xyscreens>=1.1.0` (pending library release with TCP support)
- Version bumped to `1.1.0`

## Note
The `manifest.json` `requirements` field references `xyscreens>=1.1.0`. This requires the library PR (rrooggiieerr/xyscreens.py#7) to be merged and a new PyPI release published first.